### PR TITLE
Revome jq install from travis test

### DIFF
--- a/travis/wskdeploy.sh
+++ b/travis/wskdeploy.sh
@@ -43,7 +43,6 @@ cd runtimes/nodejs # Or runtimes/[php|python|swift]
 ./wskdeploy
 
 # Test after installing prereqs
-sudo apt-get install jq
 
 bx wsk action invoke --blocking --result data-processing-cloudant/write-to-cloudant
 


### PR DESCRIPTION
The jq package should be included by default in images used by
travis.  Trying to install it again results in an error.